### PR TITLE
Update Music Manager audio list and fix looping

### DIFF
--- a/Assets/Managers/MusicManager.asset
+++ b/Assets/Managers/MusicManager.asset
@@ -13,13 +13,13 @@ MonoBehaviour:
   m_Name: MusicManager
   m_EditorClassIdentifier: 
   musicList:
-  - Song: 3
+  - Song: 4
     Intro: {fileID: 8300000, guid: 58b703802267498408b7044728e9a652, type: 3}
     introDuration: 3
     Main: {fileID: 8300000, guid: 4079607fa33808a4b963bf3ee879a6bf, type: 3}
     mainDuration: 52
     loopSong: 0
-  - Song: 1
+  - Song: 3
     Intro: {fileID: 8300000, guid: 232b9cdc38cb06744b5c8f5a50fd3998, type: 3}
     introDuration: 29
     Main: {fileID: 8300000, guid: 93ea580b82ca6f14b914d08e1d9b521d, type: 3}
@@ -30,4 +30,10 @@ MonoBehaviour:
     introDuration: 0
     Main: {fileID: 8300000, guid: 48287fd493675214f904b3ecf5070000, type: 3}
     mainDuration: 94
-    loopSong: 1
+    loopSong: 0
+  - Song: 1
+    Intro: {fileID: 0}
+    introDuration: 0
+    Main: {fileID: 8300000, guid: 6879cdb516cf47f45a13aa502cb00836, type: 3}
+    mainDuration: 94
+    loopSong: 0

--- a/Assets/Scripts/Audio/MusicManagerSO.cs
+++ b/Assets/Scripts/Audio/MusicManagerSO.cs
@@ -23,11 +23,8 @@ public enum SongName {
 [CreateAssetMenu(fileName = "MusicManager", menuName = "ScriptableObjects/Managers/MusicManager")]
 public class MusicManagerSO : ScriptableObject {
     [SerializeField] private List<MusicTrack> musicList;
-    private bool initialized = false;
 
     public void Initialize() {
-        if (initialized) return;
-
         for (int i = 0; i < musicList.Count; i++) {
             var track = musicList[i];
 
@@ -41,13 +38,14 @@ public class MusicManagerSO : ScriptableObject {
             musicList[i] = track;
         }
 
-        initialized = true;
     }
     private double clipDuration(AudioClip clip) {
-        double duration = clip.samples / clip.frequency;
+        double duration = (double)clip.samples / (double)clip.frequency;
         Debug.Log($"Clip: {clip.name}, Duration: {duration}");
         return duration;
     }
 
-    public MusicTrack FetchSong(SongName song) => musicList.Find(t => t.Song == song);
+    public MusicTrack FetchSong(SongName song) {
+       return musicList.Find(t => t.Song == song);
+    }
 }

--- a/Assets/Scripts/Audio/MusicPlayer.cs
+++ b/Assets/Scripts/Audio/MusicPlayer.cs
@@ -39,7 +39,7 @@ public class MusicPlayer : MonoBehaviour {
     // }
 
     private double getIntroPlaytime() {
-        return (double)introSource.timeSamples / introSource.clip.frequency;
+        return (double)introSource.timeSamples / (double)introSource.clip.frequency;
     }
 
     private void Update() {
@@ -54,7 +54,8 @@ public class MusicPlayer : MonoBehaviour {
 
     private IEnumerator PlaySongRoutine(SongName song) {
         // Stop the current song if any
-        yield return StartCoroutine(StopCurrentSong());
+        mainSource.Stop();
+        introSource.Stop();
 
         // Fetch the audio files
         MusicTrack track = musicData.FetchSong(song);


### PR DESCRIPTION
The Music Manager's clipDuration method was performing integer division to get a duration value in whole seconds instead of a double computation. This was causing songs to split between the intro and main portions too soon, and has been fixed.

Additionally, the crossfade has been removed when changing songs since the Game Boy unfortunately can't crossfade.